### PR TITLE
Fix example config TileMill mention.

### DIFF
--- a/examples/upstart
+++ b/examples/upstart
@@ -1,4 +1,4 @@
-# Example configuration for using TileMill with [upstart][1] on Ubuntu.
+# Example configuration for using TileStream with [upstart][1] on Ubuntu.
 #
 # [1]:http://upstart.ubuntu.com/
 #


### PR DESCRIPTION
Just noticed this - mentions TileMill instead of TileStream.
