### PR TITLE
updated repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Install node:
 
 Install TileStream:
 
-    git clone git@github.com:mapbox/tilestream.git
+    git clone https://github.com/mapbox/tilestream.git
     cd tilestream
     npm install
 


### PR DESCRIPTION
is this the more appropriate repo path for cloning to install tilestream?
