### PR TITLE
The tileHost config option broke Tilestream.  This pull request fixes it.

### DIFF
--- a/commands/global.bones
+++ b/commands/global.bones
@@ -14,8 +14,7 @@ Bones.Command.options['tilePort'] = {
 
 Bones.Command.options['tileHost'] = {
     'title': 'tileHost=[host]',
-    'description': 'Tile hostname',
-    'default': 'req.headers.host'
+    'description': 'Tile hostname'
 };
 
 Bones.Command.options['subdomains'] = {

--- a/servers/Host.bones
+++ b/servers/Host.bones
@@ -31,7 +31,7 @@ server.prototype.hostInfo = function(req, res, next) {
 
     if (req.headers && req.headers.host && !req.query.uiHost) {
         req.query.uiHost = req.headers.host;
-        req.query.tileHost = this.config.tileHost || [req.headers.host];
+        req.query.tileHost = this.config.tileHost ? [this.config.tileHost] : [req.headers.host];
         if (subdomains) {
             // Add subdomains for tiles.
             var basehost = this.removeTileSubdomain(req.headers.host);


### PR DESCRIPTION
Default the tileHost option to undefined rather than the string 'req.headers.host'.  If tileHost is undefined, use the host on the request header.  If the tileHost config option is defined then use it but put it in an array just like the host on the request header is put in an array.
