### PR TITLE
Allow running Tilestream without HOME in the environment (fixes #155)

### DIFF
--- a/commands/global.bones
+++ b/commands/global.bones
@@ -1,5 +1,12 @@
 var path = require('path');
 
+var defaultTilePath;
+if(process.env.HOME !== undefined) {
+    defaultTilePath = path.join(process.env.HOME, 'Documents', 'MapBox', 'tiles');
+} else {
+    defaultTilePath = path.join(process.cwd(), 'tiles');
+}
+
 Bones.Command.options['uiPort'] = {
     'title': 'uiPort=[port]',
     'description': 'UI server port.',
@@ -25,7 +32,7 @@ Bones.Command.options['subdomains'] = {
 Bones.Command.options['tiles'] = {
     'title': 'tiles=[path]',
     'description': 'Path to tiles directory.',
-    'default': path.join(process.env.HOME, 'Documents', 'MapBox', 'tiles')
+    'default': defaultTilePath
 };
 
 Bones.Command.options['accesslog'] = {


### PR DESCRIPTION
This falls back to serving tiles from `./tiles` in case the HOME environment variable is undefined, which makes it easier to run Tilestream under a process supervisor or from an init script (see #155).

I'm not 100% sure this is the desired behavior in a situation like this, but I figured I would get a PR up as soon as possible.

Not-so-exhaustive testing:

```
$ node --harmony index.js start --help
Usage: node index.js <command> [options...]
Commands: start application
  start

Options:
    --host               Hostnames allowed for requests. Wildcards are allowed. (Default: ["127.0.0.1","localhost","<redacted>"])
    --uiPort=[port]      UI server port. (Default: 8888)
    --tilePort=[port]    Tile server port. (Default: 8888)
    --tileHost=[host]    Tile hostname (Default: undefined)
    --subdomains=[list]  Comma separated list of subdomains to use for tiles. (Default: undefined)
    --tiles=[path]       Path to tiles directory. (Default: "/home/users/wrigby/Documents/MapBox/tiles")
    --accesslog          Print every request to stdout. (Default: false)
    --config=[path]      Path to JSON configuration file.
$ unset HOME
$ node --harmony index.js start --help
Usage: node index.js <command> [options...]
Commands: start application
  start

Options:
    --host               Hostnames allowed for requests. Wildcards are allowed. (Default: ["127.0.0.1","localhost","<redacted>"])
    --uiPort=[port]      UI server port. (Default: 8888)
    --tilePort=[port]    Tile server port. (Default: 8888)
    --tileHost=[host]    Tile hostname (Default: undefined)
    --subdomains=[list]  Comma separated list of subdomains to use for tiles. (Default: undefined)
    --tiles=[path]       Path to tiles directory. (Default: "/usr/lib/node_modules/tiles")
    --accesslog          Print every request to stdout. (Default: false)
    --config=[path]      Path to JSON configuration file.
```
